### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Compiled Python
+*.pyc
+
+# Jupyter caches
+.ipynb_checkpoints/
+


### PR DESCRIPTION
There's no `.gitignore` in the class repo, so people might accidentally commit random artifacts created by Python and Jupyter. I'd like to gate these types of files to prevent git or unsuspecting users from accidentally committing them.